### PR TITLE
Null and name fixes

### DIFF
--- a/Solutions/src/Other/Solution.xml
+++ b/Solutions/src/Other/Solution.xml
@@ -5,10 +5,10 @@
     <UniqueName>Solutions</UniqueName>
     <LocalizedNames>
       <!-- Localized Solution Name in language code -->
-      <LocalizedName description="Solutions" languagecode="1033" />
+      <LocalizedName description="UK PostCode Validation" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0</Version>
+    <Version>1.0.2</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/UKPostCodeValidation/index.ts
+++ b/UKPostCodeValidation/index.ts
@@ -32,7 +32,7 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
     this._inputElement = document.createElement("input");
     this._inputElement.setAttribute("type", "text");
     this._inputElement.setAttribute("placeholder", "");
-    this._value = context.parameters.postCode.raw!;
+    this._value = context.parameters.postCode.raw || ""; //amended
     this._inputElement.value = this._value;
     this._notifyOutputChanged = notifyOutputChanged;
     this._refreshData = this.refreshData.bind(this);
@@ -49,7 +49,7 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
     this._container.appendChild(errorIconLabelElement);
     this._container.appendChild(errorLabelElement);
 
-    if(this.validation.test(context.parameters.postCode.raw!) == true && context.parameters.postCode.raw!.length > 0) {
+    if(this.validation.test(this._value) == true && this._value.length > 0) {//this._value.length
         this._inputElement.setAttribute("style", "background: green");
         this.labelElement.innerHTML = "Success";
     } else if (context.parameters.postCode.raw!.length == 0) {

--- a/UKPostCodeValidation/index.ts
+++ b/UKPostCodeValidation/index.ts
@@ -52,8 +52,9 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
     if(this.validation.test(this._value) == true && this._value != "") {//this._value.length
         this._inputElement.setAttribute("style", "background: green");
         this.labelElement.innerHTML = "Success";
-    } else if (this._value == "") {
+    } else if (context.parameters.postCode.raw! == "" || context.parameters.postCode.raw! == null || context.parameters.postCode.raw! == undefined || 0) {
         this._inputElement.setAttribute("style", "background: white");
+        this._container.style.display = "none"; // Hide the error container
     } else {
         this._inputElement.setAttribute("style", "background: red");
     }
@@ -65,7 +66,7 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
 
 
     public refreshData(evt: Event): void {
-        this._value = (this._inputElement.value as any) as string;
+        this._value = (this._inputElement.value);
         this.labelElement.innerHTML = this._inputElement.value;
         this._notifyOutputChanged();
      }
@@ -80,7 +81,7 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
         this._inputElement.setAttribute("style", "background: green");
         this.labelElement.innerHTML = "Success";
         this._container.style.display = "none"; // Hide the error container
-    } else if (context.parameters.postCode.raw! == "") {
+    } else if (context.parameters.postCode.raw! == "" || null || undefined || 0) {
         this._inputElement.setAttribute("style", "background: white");
         this._container.style.display = "none"; // Hide the error container
     } else {

--- a/UKPostCodeValidation/index.ts
+++ b/UKPostCodeValidation/index.ts
@@ -49,10 +49,10 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
     this._container.appendChild(errorIconLabelElement);
     this._container.appendChild(errorLabelElement);
 
-    if(this.validation.test(this._value) == true && this._value.length > 0) {//this._value.length
+    if(this.validation.test(this._value) == true && this._value != "") {//this._value.length
         this._inputElement.setAttribute("style", "background: green");
         this.labelElement.innerHTML = "Success";
-    } else if (context.parameters.postCode.raw!.length == 0) {
+    } else if (this._value == "") {
         this._inputElement.setAttribute("style", "background: white");
     } else {
         this._inputElement.setAttribute("style", "background: red");
@@ -76,11 +76,11 @@ export class UKPostCodeValidation implements ComponentFramework.StandardControl<
      */
     public updateView(context: ComponentFramework.Context<IInputs>): void
 {
-    if(this.validation.test(context.parameters.postCode.raw!) == true && context.parameters.postCode.raw!.length > 0) {
+    if(this.validation.test(context.parameters.postCode.raw!) == true && context.parameters.postCode.raw! != "") {
         this._inputElement.setAttribute("style", "background: green");
         this.labelElement.innerHTML = "Success";
         this._container.style.display = "none"; // Hide the error container
-    } else if (context.parameters.postCode.raw!.length == 0) {
+    } else if (context.parameters.postCode.raw! == "") {
         this._inputElement.setAttribute("style", "background: white");
         this._container.style.display = "none"; // Hide the error container
     } else {


### PR DESCRIPTION
Altered the checks to remove the length check and instead add a check for null or undefined as a condition. This now lets the component load and render correctly when a form is in new mode or where a postcode hasn't previously been applied.